### PR TITLE
Supporting query param fixtures

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,7 @@
 var fs     = require('fs');
 var path   = require('path');
 var mkdirp = require('mkdirp');
+var url    = require('url');
 
 module.exports = function(options) {
   var fixtures;
@@ -45,26 +46,32 @@ module.exports = function(options) {
       var moduleName = req.headers['x-module-name'];
       var testName   = req.headers['x-test-name'];
       var method     = res.req.method.toLowerCase();
+      var parsedUrl  = url.parse(res.req.url);
+      var pathname   = parsedUrl.pathname;
+      var query      = parsedUrl.query || '';
 
-      var fixture = {
-        statusCode: res.statusCode,
-        headers: {},
-        body: body
-      };
+      if (moduleName && testName) {
+        var fixture = {
+          statusCode: res.statusCode,
+          headers: {},
+          body: body
+        };
 
-      for (var headerKey in res._headers) {
-        fixture.headers[res._headerNames[headerKey]] = res._headers[headerKey];
+        for (var headerKey in res._headers) {
+          fixture.headers[res._headerNames[headerKey]] = res._headers[headerKey];
+        }
+
+        fixtures[moduleName]                                    = fixtures[moduleName]                                    || {};
+        fixtures[moduleName][testName]                          = fixtures[moduleName][testName]                          || {};
+        fixtures[moduleName][testName][pathname]                = fixtures[moduleName][testName][pathname]                || {};
+        fixtures[moduleName][testName][pathname][method]        = fixtures[moduleName][testName][pathname][method]        || {};
+        fixtures[moduleName][testName][pathname][method][query] = fixtures[moduleName][testName][pathname][method][query] || {
+          fixtures: [],
+          offset: 0
+        };
+
+        fixtures[moduleName][testName][pathname][method][query].fixtures.push(fixture);
       }
-
-      fixtures[moduleName]                                        = fixtures[moduleName]                                        || {};
-      fixtures[moduleName][testName]                              = fixtures[moduleName][testName]                              || {};
-      fixtures[moduleName][testName][res.req.originalUrl]         = fixtures[moduleName][testName][res.req.originalUrl]         || {};
-      fixtures[moduleName][testName][res.req.originalUrl][method] = fixtures[moduleName][testName][res.req.originalUrl][method] || {
-        fixtures: [],
-        offset: 0
-      };
-
-      fixtures[moduleName][testName][res.req.originalUrl][method].fixtures.push(fixture);
     };
   };
 };

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -18,11 +18,15 @@ QUnit.proxyFixtures = function(name) {
         server = new Pretender(function() {
           for (var path in fixtures) {
             for (var method in fixtures[path]) {
-              this[method](path, function(request) {
-                var fixture = fixtures[path][method].fixtures[fixtures[path][method].offset];
-                fixtures[path][method].offset += 1;
-                return [fixture.statusCode, fixture.headers, fixture.body];
-              });
+              var code = "" +
+                "var proxyFixtures = window['"+name+"'];\n" +
+                "var query = Ember.$.param(request.queryParams);\n" +
+                "var fixtures = proxyFixtures['"+details.module+"']['"+details.name+"'];\n" +
+                "var fixture = fixtures['"+path+"']['"+method+"'][query].fixtures[fixtures['"+path+"']['"+method+"'][query].offset];\n" +
+                "fixtures['"+path+"']['"+method+"'][query].offset += 1;\n" +
+                "return [fixture.statusCode, fixture.headers, fixture.body];\n";
+              var fn = new Function("server", "request", code);
+              this[method](path, fn.bind("request", this));
             }
           }
         });


### PR DESCRIPTION
Pretender's route recognizer parses query params out of the url

Fixtures now store responses with query params as a key
