### PR TITLE
Unzip responses

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,7 @@
 var fs     = require('fs');
 var path   = require('path');
 var mkdirp = require('mkdirp');
+var zlib   = require('zlib');
 var url    = require('url');
 
 module.exports = function(options) {
@@ -12,7 +13,14 @@ module.exports = function(options) {
   return function(req, res, next) {
     var write = res.write;
     res.write = function(body) {
-      addFixture(this, body.toString());
+      if (res._headers['content-encoding'] === 'gzip') {
+        var _this = this;
+        zlib.unzip(body, function(err, body) {
+          addFixture(_this, body.toString());
+        });
+      } else {
+        addFixture(this, body.toString());
+      }
       return write.apply(this, arguments);
     };
 
@@ -60,6 +68,8 @@ module.exports = function(options) {
         for (var headerKey in res._headers) {
           fixture.headers[res._headerNames[headerKey]] = res._headers[headerKey];
         }
+
+        delete fixture.headers['content-encoding'];
 
         fixtures[moduleName]                                    = fixtures[moduleName]                                    || {};
         fixtures[moduleName][testName]                          = fixtures[moduleName][testName]                          || {};


### PR DESCRIPTION
Closes #5 

I am uncertain why `zlib.unzip` worked but `zlib.gunzip` did not considering that the compression type indicated in the `content-ecoding` header is `gzip`. So this has **works for me** status.
