### PR TITLE
allow recording and playback of 'error' ajax calls

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -33,6 +33,7 @@ module.exports = function(options) {
             method:     request.method,
             url:        request.url,
             statusCode: request.statusCode,
+            statusText: request.statusText,
             headers:    request.headers
           };
           addFixture(options, JSON.stringify(request.body));
@@ -75,6 +76,7 @@ module.exports = function(options) {
         method:      res.req.method.toLowerCase(),
         url:         res.req.url,
         statusCode:  res.statusCode,
+        statusText:  res.statusText,
         headers:     {}
       };
 
@@ -98,6 +100,7 @@ module.exports = function(options) {
       if (moduleName && testName) {
         var fixture = {
           statusCode: options.statusCode,
+          statusText: options.statusText,
           headers: options.headers,
           body: body
         };

--- a/lib/qunit.js
+++ b/lib/qunit.js
@@ -58,6 +58,8 @@ ProxyFixtures.prototype.testStart = function(details) {
 
   Ember.$(document).on('ajaxSuccess',
                         Ember.run.bind(instance, instance.cacheRequest));
+  Ember.$(document).on('ajaxError',
+                        Ember.run.bind(instance, instance.cacheRequest));
 
   var proxyFixtures = window[instance.name];
 
@@ -96,6 +98,8 @@ ProxyFixtures.prototype.testStart = function(details) {
         fixture.headers['x-mockjax-response'] = 'true';
 
         return {
+          status:        fixture.statusCode,
+          statusText:    fixture.statusText,
           responseTime:  0,
           method:        settingsMethod,
           headers:       fixture.headers,
@@ -119,6 +123,7 @@ ProxyFixtures.prototype.testDone = function() {
   });
 
   Ember.$(document).off('ajaxSuccess', Ember.run.bind(this, this.cacheRequest));
+  Ember.$(document).off('ajaxError', Ember.run.bind(this, this.cacheRequest));
   Ember.$.mockjax.clear();
 };
 
@@ -146,6 +151,9 @@ ProxyFixtures.prototype.cacheRequest = function(e, xhr, settings) {
     headers:     headers,
     body:        JSON.parse(xhr.responseText.length > 1 ? xhr.responseText : '{}')
   };
+  if (xhr.statusText) {
+    cachedRequest.statusText = xhr.statusText;
+  }
 
   this.cachedRequests.push(cachedRequest);
 };

--- a/tests/unit/middleware-test.js
+++ b/tests/unit/middleware-test.js
@@ -74,6 +74,15 @@ describe('Middleware', function() {
               statusCode: 200,
               headers: {},
               body: { users: [] }
+            },
+            {
+              reqHeaders: { 'x-module-name': 'test', 'x-test-name': 'test-get' },
+              method: 'GET',
+              url: '/private-users',
+              statusCode: 401,
+              statusText: 'Unauthorized',
+              headers: {},
+              body: { users: [] }
             }
           ]);
 
@@ -102,6 +111,17 @@ describe('Middleware', function() {
           assert.equal(fixture.body, '{"users":[]}');
           assert.deepEqual(fixture.headers, {});
 
+        });
+        
+        it ('records an errored response', function () {
+          var fixture = this.fixture['/private-users']['get'][''].fixtures[0];
+          
+          assert.deepEqual(Object.keys(fixture),
+                          ['statusCode', 'statusText', 'headers', 'body']);
+          assert.equal(fixture.statusCode, 401);
+          assert.equal(fixture.statusText, "Unauthorized");
+          assert.equal(fixture.body, '{"users":[]}');
+          assert.deepEqual(fixture.headers, {});
         });
       });
 

--- a/tests/unit/qunit-test.js
+++ b/tests/unit/qunit-test.js
@@ -224,6 +224,8 @@ describe('ProxyFixtures', function() {
           });
 
           assert.deepEqual(res, {
+            status: 200,
+            statusText: undefined,
             responseTime: 0,
             method: 'GET',
             headers: {
@@ -244,6 +246,8 @@ describe('ProxyFixtures', function() {
           });
 
           assert.deepEqual(res, {
+            status: 200,
+            statusText: undefined,
             responseTime: 0,
             method: 'GET',
             headers: {
@@ -275,6 +279,8 @@ describe('ProxyFixtures', function() {
           });
 
           assert.deepEqual(res, {
+            status: 200,
+            statusText: undefined,
             responseTime: 0,
             method: 'GET',
             headers: {
@@ -420,6 +426,46 @@ describe('ProxyFixtures', function() {
           }
         }
       });
+    }); 
+
+    it('adds erroring request to cachedRequests', function() {
+      assert.equal(proxyFixtures.cachedRequests.length, 0);
+
+      proxyFixtures.cacheRequest(null, {
+        getAllResponseHeaders: function() {
+          return 'x-random-header:false';
+        },
+        responseText: '{"user":{"name":"Jake"}}',
+        status: 401,
+        statusText: 'Unauthorized'
+      }, {
+        url: 'http://localhost:4000/api/v1/private-users/1',
+        type: 'GET',
+        headers: {
+          'x-module-name': 'test',
+          'x-test-name': 'test'
+        }
+      });
+
+      assert.equal(proxyFixtures.cachedRequests.length, 1);
+      assert.deepEqual(proxyFixtures.cachedRequests[0], {
+        url:         'http://localhost:4000/api/v1/private-users/1',
+        statusCode:  401,
+        statusText:  'Unauthorized',
+        method:      'GET',
+        reqHeaders: {
+          'x-module-name': 'test',
+          'x-test-name': 'test'
+        },
+        headers: {
+          'x-random-header': 'false'
+        },
+        body: {
+          user: {
+            name: 'Jake'
+          }
+        }
+      });
     });
   });
 
@@ -445,7 +491,7 @@ describe('ProxyFixtures', function() {
 
         assert.equal(parsed.path, url);
       });
-    })
+    });
 
     describe('query', function() {
       it('is present', function() {


### PR DESCRIPTION
Useful for checking that code responds correctly to ajax 'error' states, such as permission-based calls where the client is unauthorized.
